### PR TITLE
[Feature] Use Binary in Terra Contract

### DIFF
--- a/bridge/pkg/terra/sender.go
+++ b/bridge/pkg/terra/sender.go
@@ -29,7 +29,7 @@ type SubmitVAAMsg struct {
 }
 
 type SubmitVAAParams struct {
-	VAA JSONArraySlice `json:"vaa"`
+	VAA byte[] `json:"vaa"`
 }
 
 // SubmitVAA Prepares transaction with signed VAA and sends it to the Terra blockchain

--- a/terra/contracts/wormhole/src/msg.rs
+++ b/terra/contracts/wormhole/src/msg.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{HumanAddr, Uint128};
+use cosmwasm_std::{Binary, HumanAddr, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -15,15 +15,15 @@ pub struct InitMsg {
 #[serde(rename_all = "snake_case")]
 pub enum HandleMsg {
     SubmitVAA {
-        vaa: Vec<u8>,
+        vaa: Binary,
     },
     RegisterAssetHook {
-        asset_id: Vec<u8>,
+        asset_id: Binary,
     },
     LockAssets {
         asset: HumanAddr,
         amount: Uint128,
-        recipient: Vec<u8>,
+        recipient: Binary,
         target_chain: u8,
         nonce: u32,
     },
@@ -31,9 +31,9 @@ pub enum HandleMsg {
         target_chain: u8,
         token_chain: u8,
         token_decimals: u8,
-        token: Vec<u8>,
-        sender: Vec<u8>,
-        recipient: Vec<u8>,
+        token: Binary,
+        sender: Binary,
+        recipient: Binary,
         amount: Uint128,
         nonce: u32,
     },

--- a/terra/contracts/wormhole/src/state.rs
+++ b/terra/contracts/wormhole/src/state.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{CanonicalAddr, HumanAddr, StdResult, Storage};
+use cosmwasm_std::{Binary, CanonicalAddr, HumanAddr, StdResult, Storage};
 use cosmwasm_storage::{
     bucket, bucket_read, singleton, singleton_read, Bucket, ReadonlyBucket, ReadonlySingleton,
     Singleton,
@@ -34,7 +34,7 @@ pub struct ConfigInfo {
 // Guardian address
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct GuardianAddress {
-    pub bytes: Vec<u8>, // 20-byte addresses
+    pub bytes: Binary, // 20-byte addresses
 }
 
 #[cfg(test)]
@@ -43,7 +43,7 @@ use hex;
 impl GuardianAddress {
     pub fn from(string: &str) -> GuardianAddress {
         GuardianAddress {
-            bytes: hex::decode(string).expect("Decoding failed"),
+            bytes: Binary::from(hex::decode(string).expect("Decoding failed")),
         }
     }
 }

--- a/terra/contracts/wormhole/tests/integration.rs
+++ b/terra/contracts/wormhole/tests/integration.rs
@@ -1,6 +1,6 @@
 static WASM: &[u8] = include_bytes!("../../../target/wasm32-unknown-unknown/release/wormhole.wasm");
 
-use cosmwasm_std::{from_slice, Env, HumanAddr, InitResponse};
+use cosmwasm_std::{from_slice, Env, HumanAddr, InitResponse, Binary};
 use cosmwasm_storage::to_length_prefixed;
 use cosmwasm_vm::testing::{init, mock_env, mock_instance, MockApi, MockQuerier, MockStorage};
 use cosmwasm_vm::{Instance, Storage, Api};
@@ -78,7 +78,7 @@ fn do_init(
 #[test]
 fn init_works() {
     let guardians = vec![GuardianAddress::from(GuardianAddress {
-        bytes: hex::decode("beFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe").expect("Decoding failed"),
+        bytes: Binary::from(hex::decode("beFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe").expect("Decoding failed")),
     })];
     let _deps = do_init(111, &guardians);
 }


### PR DESCRIPTION
Update `Vec<u8>` type to `Binary` to reduce the encoded msg size.

fix: https://github.com/certusone/wormhole/issues/100